### PR TITLE
Improve CVE handling, Debian release compatibility and snapshot sources management

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -1,0 +1,30 @@
+name: Python CI (Pylint + Pytest)
+
+on:
+  push:
+    paths:
+      - decret/decret.py
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Lint with pylint (fail only on errors)
+      run: pylint --disable broad-exception-raised decret
+
+    - name: Run tests with pytest
+      run: pytest

--- a/README.md
+++ b/README.md
@@ -80,6 +80,13 @@ pytest
 5. Verify your code passes CI tests under `.github/workflows`
 6. Open pull request
 
+### Troubleshooting
+If you encounter any issues, please refer to the [Troubleshooting Journal](./TROUBLESHOOTING.md) for solutions.
+
+### Additional notes
+- Make sure to respect the configuration file syntax.  
+- For more details, refer to the source code and comments in `decret_auto/decret_auto.py`.
+
 ## Working principle
 
 ![](./img/reproduction_implementation.png)

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,0 +1,28 @@
+# Firefox environment error: InvalidArgumentException when running tests
+
+## Error message example
+````bash
+selenium.common.exceptions.InvalidArgumentException: Message: binary is not a Firefox executable
+````
+
+## When does this happen?
+This error can occur when running DECRET, or its tests (for example, with `pytest` command) if Firefox was installed with `Snap` or if the wrong Firefox binary is being used.  
+It often happens when:  
+- Firefox is installed with `Snap` instead of `apt`.
+- Multiple Firefox installations are present on the system (for example, both `snap` and `apt` versions installed at the same time).
+- There are conflicting Firefox installations.  
+
+Having more than one Firefox installation  can cause conflicts and lead to this error.
+
+## How to fix
+Don’t reinstall Selenium or try other installations!
+Instead, clean up your Firefox installation and make sure you’re using the correct version:
+```bash
+sudo snap remove firefox
+sudo apt update
+sudo apt install firefox-esr
+snap list | grep firefox # Should display nothing...
+apt list --installed | grep firefox
+```  
+
+After following the steps above, you can check that everything works by running: `pytest`

--- a/decret/decret.py
+++ b/decret/decret.py
@@ -249,6 +249,21 @@ def prepare_browser():
 
 
 def search_in_table(release: str, info_table) -> Tuple[list[dict], list[str]]:
+    """
+    Parses the CVE table extract package information for the specified Debian release.
+
+    Args:
+        release (str): The Debian release to search for (e.g., 'bullseye').
+        info_table: The Selenium object representing the CVE HTML table.
+
+    Returns:
+        Tuple[list[dict], list[str]]:
+            - List of dictionaries with package info for the requested release.
+            - List of all available releases found in the table.
+
+    Raises:
+        ReleaseNotAffectedByCVE: If the release is not affected by the CVE.    
+    """
     results = []
     available_releases = []
     i = 0
@@ -272,6 +287,11 @@ def search_in_table(release: str, info_table) -> Tuple[list[dict], list[str]]:
                 src_package = data[0]
                 release = data[2]
                 fixed_version = data[3]
+                if (str(fixed_version).strip().startswith("(not")):
+                    tmp = " ".join(data[3:])
+                    raise ReleaseNotAffectedByCVE(f"Debian {release} was not affected by CVE "
+                                                  f"for package '{src_package}'. "
+                                                  f"Invalid fixed_version detected: '{tmp}'.")
                 results.append(
                     {
                         "src_package": src_package,
@@ -660,21 +680,29 @@ def main():  # pragma: no cover
 
         try:
             cve_details = get_cve_details_from_selenium(browser, args)
+        except ReleaseNotAffectedByCVE as invalid_exc:
+            raise FatalError(
+                f"\n{invalid_exc}"
+            ) from invalid_exc
+        
         except Exception as selenium_exc:
             raise FatalError(
                 "Error while retrieving CVE details using Selenium"
-            ) from selenium_exc
+            ) from selenium_exc 
         
     except ReleaseNotAffectedByCVE as exc:
         raise FatalError(exc)
    
+    # vuln_fixed is False if (unfixed) in cve_details
+    vuln_fixed = not any(item["fixed_version"] == "(unfixed)" for item in cve_details)
     print(f"CVE details fetched.\n {cve_details}\n\n") 
+    
     # Get the vulnerable version for the affected package.
     print("Getting the vulnerable version.")
     cve_details = get_vuln_version(args, cve_details)
     print(f"vulnerable version : {cve_details[0]['vuln_version']}\n\n")
+    
     # We determine if the vulnerability is fixed or not
-    vuln_fixed = not any(item["fixed_version"] == "(unfixed)" for item in cve_details)
     print("Getting the hash of the package")
     cve_details = get_hash_and_bin_names(args, cve_details)
     print(f"Source package hash : {cve_details[0]['hash']}\n\n")
@@ -695,6 +723,9 @@ def main():  # pragma: no cover
             browser.quit()
 
     source_lines = prepare_sources(snapshot_id, vuln_fixed)
+    if not vuln_fixed:
+        print(f"\n\nVulnerability unfixed. Using a {LATEST_RELEASE} container.\n\n")
+        args.release = LATEST_RELEASE
 
     write_dockerfile(args, cve_details, source_lines)
     write_cmdline(args)

--- a/decret/decret.py
+++ b/decret/decret.py
@@ -1,7 +1,7 @@
 """
 Software Name : decret (DEbian Cve REproducer Tool)
 Version : 0.1
-SPDX-FileCopyrightText : Copyright (c) 2023-2025 Orange
+SPDX-FileCopyrightText : Copyright (c) 2023-2026 Orange
 SPDX-License-Identifier : BSD-3-Clause
 
 This software is distributed under the BSD 3-Clause "New" or "Revised" License,
@@ -9,7 +9,7 @@ the text of which is available at https://opensource.org/licenses/BSD-3-Clause
 or see the "license.txt" file for more not details.
 
 Authors : Clément PARSSEGNY, Olivier LEVILLAIN, Maxime BELAIR, Mathieu BACOU,
-Nicolas DEJON
+Nicolas DEJON, Zakaria CHAKER
 Software description : A tool to reproduce vulnerability affecting Debian
 It gathers details from the Debian metadata and exploits from exploit-db.com
 in order to build and run a vulnerable Docker container to test and

--- a/decret/decret.py
+++ b/decret/decret.py
@@ -74,6 +74,10 @@ class CVENotFound(BaseException):
     pass
 
 
+class ReleaseNotAffectedByCVE(BaseException):
+    pass
+
+
 def arg_parsing(args=None):
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -370,9 +374,10 @@ def get_cve_details_from_json(args: argparse.Namespace) -> list[dict]:
             repositories = release_info.get("repositories", {})
             vulnerable_version = repositories.get(args.release)
         else:
+            # If fixed, get the fixed version package
             fixed_version = cve_info["releases"][args.release]["fixed_version"]
         if fixed_version == "0":
-            raise CVENotFound(
+            raise ReleaseNotAffectedByCVE(
                 f"Debian {args.release} was not affected by {cve_id}.\n"
                 f"Try another release."
                 f"(see https://security-tracker.debian.org/tracker/CVE-{args.cve_number})."
@@ -659,11 +664,12 @@ def main():  # pragma: no cover
             raise FatalError(
                 "Error while retrieving CVE details using Selenium"
             ) from selenium_exc
-
-    # vuln_fixed is False if (unfixed) in cve_details
-    vuln_fixed = not any(item["fixed_version"] == "(unfixed)" for item in cve_details)
-    print(f"CVE details fetched.\n {cve_details}\n\n")
-
+        
+    except ReleaseNotAffectedByCVE as exc:
+        raise FatalError(exc)
+   
+    print(f"CVE details fetched.\n {cve_details}\n\n") 
+    # Get the vulnerable version for the affected package.
     print("Getting the vulnerable version.")
     cve_details = get_vuln_version(args, cve_details)
     print(f"vulnerable version : {cve_details[0]['vuln_version']}\n\n")
@@ -689,12 +695,6 @@ def main():  # pragma: no cover
             browser.quit()
 
     source_lines = prepare_sources(snapshot_id, vuln_fixed)
-    # If the vulnerability is unfixed and the version is not found, use the latest release
-    if not vuln_fixed:
-        print(f"\n\nVulnerability unfixed. Using a {LATEST_RELEASE} container.\n\n")
-        args.release = LATEST_RELEASE
-    else:
-        print("\n\nVulnerable package available.\n\n")
 
     write_dockerfile(args, cve_details, source_lines)
     write_cmdline(args)

--- a/decret/decret.py
+++ b/decret/decret.py
@@ -287,7 +287,7 @@ def search_in_table(release: str, info_table) -> Tuple[list[dict], list[str]]:
                 src_package = data[0]
                 release = data[2]
                 fixed_version = data[3]
-                if (str(fixed_version).strip().startswith("(not")):
+                if str(fixed_version).strip().startswith("(not"):
                     tmp = " ".join(data[3:])
                     raise ReleaseNotAffectedByCVE(f"Debian {release} was not affected by CVE "
                                                   f"for package '{src_package}'. "
@@ -341,14 +341,20 @@ def get_cve_details_from_selenium(browser, args: argparse.Namespace) -> list[dic
     return results
 
 
-def get_cve_details_from_json(args: argparse.Namespace) -> list[dict]:
+def get_cve_details_from_json(args: argparse.Namespace) -> list[dict]: # pylint: disable=too-many-locals,too-many-branches
     """
-    Parses the Debian Security Tracker JSON file to extract details about a given CVE for a specific Debian release.
-    Supports loading the JSON from a cache file if provided, otherwise fetches it from the official Debian tracker.
-    Handles cases where the package is present but the vulnerability is not fixed, by checking the repositories field:
-    - If the CVE is fixed for the current release, returns a list with: {'src_package', 'release', 'fixed_version'}.
-    - If the CVE is unfixed and the vulnerable package is not found retun a list with : {'src_package', 'release', 'unfixed'}
-    - If the CVE is unfixed but the vulnerable package is available, adds the key 'vulnerable_version' to {'src_package', 'release', 'unfixed'}.
+    Parses the Debian Security Tracker JSON file
+    to extract details about a given CVE for a specific Debian release.
+    Supports loading the JSON from a cache file if provided, 
+    otherwise fetches it from the official Debian tracker.
+    Handles cases where the package is present but the vulnerability isn't fixed,
+    by checking the repositories field:
+    - If the CVE is fixed for the current release, 
+    returns a list with: {'src_package', 'release', 'fixed_version'}.
+    - If the CVE is unfixed and the vulnerable package is not found 
+    returns a list with : {'src_package', 'release', 'unfixed'}
+    - If the CVE is unfixed but the vulnerable package is available, 
+    adds the key 'vulnerable_version' to {'src_package', 'release', 'unfixed'}.
 
     Returns:
         cve_details: a list of dictionaries with the package name, release, and fix status.
@@ -385,10 +391,9 @@ def get_cve_details_from_json(args: argparse.Namespace) -> list[dict]:
             continue
         affected_packages.append((package_name, cve_info))
 
-    if not affected_packages: 
+    if not affected_packages:
         raise CVENotFound("No affected package found.")
-        
-    # Step 2: Build results, skip packages with fixed_version == "0", only if other packages have a valid fixed_version
+    # Build results, skip packages fixed_version == "0", only if others have a valid fixed_version
     results = []
     for package_name, cve_info in affected_packages:
         # Get the release specific info for this CVE
@@ -401,11 +406,13 @@ def get_cve_details_from_json(args: argparse.Namespace) -> list[dict]:
             # Try to get the vulnerable version from the repositories field (`repositories` key)
             repositories = release_info.get("repositories", {})
             vulnerable_version = repositories.get(args.release)
+
         else:
             # If fixed, get the fixed version package
             fixed_version = cve_info["releases"][args.release]["fixed_version"]
             if fixed_version == "0":
                 continue
+
         #Build the result (dictionary) for this package/release
         result = {
                 "src_package": package_name,
@@ -415,7 +422,6 @@ def get_cve_details_from_json(args: argparse.Namespace) -> list[dict]:
         # If a vulnerable version is available, add it to the result
         if vulnerable_version:
             result["vulnerable_version"] = vulnerable_version
-        
         results.append(result)
         break # Only one valid package is selected
 
@@ -431,6 +437,18 @@ def get_cve_details_from_json(args: argparse.Namespace) -> list[dict]:
 
 
 def get_vuln_version(args: argparse.Namespace, cve_details: list[dict]) -> list[dict]:
+    """
+    Retrieves the vulnerable version for each package, 
+    using both the JSON data and snapshot.debian.org.
+    For each package, determines the vulnerable version based on the CVE details 
+    and available package version for the specified release.
+
+    Returns:
+        cve_details : The updated list of dictionaries with the 'vuln_version' key added.
+
+    Raises:
+        Exception: If no vulnerable version can be found for a package.
+    """
     for item in cve_details:
         if args.vulnerable_version:
             item["vuln_version"] = args.vulnerable_version
@@ -438,16 +456,18 @@ def get_vuln_version(args: argparse.Namespace, cve_details: list[dict]) -> list[
         url = f"http://snapshot.debian.org/mr/package/{item['src_package']}/"
         response = requests.get(url, timeout=DEFAULT_TIMEOUT).json()["result"]
         known_versions = [x["version"] for x in response if "~bpo" not in x["version"]]
+
         # If the package is unfixed
         if item["fixed_version"] == "(unfixed)":
             # If a vulnerable version is already known (from the JSON), we use it
             if "vulnerable_version" in item and item["vulnerable_version"]:
                 item["vuln_version"] = item["vulnerable_version"]
+
             # Otherwise, we use the latest available version from snapshot.debian.org (index 0)
             elif known_versions:
                 item["vuln_version"] = known_versions[0]
             else:
-                item["vuln_version"] = None   
+                item["vuln_version"] = None
         else:
             for version, prev_version in zip(known_versions[:-1], known_versions[1:]):
                 if version == item["fixed_version"]:
@@ -460,10 +480,11 @@ def get_vuln_version(args: argparse.Namespace, cve_details: list[dict]) -> list[
 
 def get_bin_names(cve_details: list[dict]) -> list[str]:
     """
-    For each package in cve_details, retrieves the binary package names associated with the vulnerable version.
+    For each package in cve_details, retrieves the binary package names
+    associated with the vulnerable version.
     Excludes debug, development, documentation and installer packages.
     """
-    EXCLUDED_SUFFIXES = {'-dbgsym', '-dbg', '-udeb', '-doc', '-dev'}
+    excluded_suffixes = {'-dbgsym', '-dbg', '-udeb', '-doc', '-dev'}
     bin_names = []
     for item in cve_details:
         # pylint: disable=line-too-long
@@ -471,7 +492,7 @@ def get_bin_names(cve_details: list[dict]) -> list[str]:
         response = requests.get(url, timeout=DEFAULT_TIMEOUT).json()["result"]
         for res in response:
             name = res["name"]
-            if not any(name.endswith(suffix) for suffix in EXCLUDED_SUFFIXES):
+            if not any(name.endswith(suffix) for suffix in excluded_suffixes):
                 bin_names.append(name)
 
     return bin_names
@@ -481,7 +502,8 @@ def get_hash_and_bin_names(
     args: argparse.Namespace, cve_details: list[dict]
 ) -> list[dict]:
     """
-    For each package in cve_details, retrieves the hash of the vulnerable version and the associated binary package name.
+    For each package in cve_details, retrieves the hash of the vulnerable version
+    and the associated binary package name.
     Tries to fetch the hash from the binary files.
     Updates each dictionary with the 'hash' and 'bin_name' keys.
 
@@ -512,7 +534,6 @@ def get_hash_and_bin_names(
                 response = requests.get(url, timeout=DEFAULT_TIMEOUT).json()["result"]
                 item["hash"] = response[-1]["hash"]
                 item["bin_name"] = get_bin_names(cve_details)
-
             except Exception as exc:
                 raise Exception(
                     "Couldn't find the source files for the Linux packages."
@@ -573,21 +594,24 @@ def get_snapshot_aliases(snapshot_id: str) -> dict:
 
     Returns:
         dict: A dictionary mapping aliases to release names.
-              For example: {'stable': 'bookworm', 'testing': 'trixie', 'oldstable': 'bullseye', 'oldoldstable': 'buster', 'unstable': 'sid'}
+              For example: {'stable': 'bookworm', 'testing': 'trixie',
+                            'oldstable': 'bullseye', 'oldoldstable': 'buster', 'unstable': 'sid'}
     """
     url = f"http://snapshot.debian.org/archive/debian/{snapshot_id}/dists/"
     try:
         server_answer = requests.get(url, timeout=DEFAULT_TIMEOUT)
         server_answer.raise_for_status()
+    # pylint: disable=broad-except
     except Exception as exc:
         print(f"Could not parse snapshot aliases: {exc}")
         return {}
-    
     aliases = {}
-
-    # Match HTML symlink entries like: <a href="oldstable">oldstable</a> -&gt; <a href="bullseye">bullseye</a>
-    pattern = re.compile(r'<a href="(stable|testing|unstable|oldstable|oldoldstable)">\1</a>\s*-&gt;\s*<a href="([\w-]+)">\2</a>')
-
+    # Match HTML symlink entries like:
+    # <a href="oldstable">oldstable</a> -&gt; <a href="bullseye">bullseye</a>
+    pattern = re.compile(
+        r'<a href="(stable|testing|unstable|oldstable|oldoldstable)">'
+        r'\1</a>\s*-&gt;\s*<a href="([\w-]+)">\2</a>'
+    )
     for match in pattern.finditer(server_answer.text):
         alias = match.group(1).strip()
         target = match.group(2).strip()
@@ -596,49 +620,82 @@ def get_snapshot_aliases(snapshot_id: str) -> dict:
     return aliases
 
 
-def prepare_sources(snapshot_id: str, vuln_fixed: bool, release: str = None):
+def prepare_sources(snapshot_id: str, release: str = None):
     """
     Generates the Debian snapshot APT source lines for the Dockerfile.
-    For bookworm/trixie, uses the original alias-based logic (testing/stable/unstable). 
-    For older releases, parses the snapshot to determine the correct source strategy:
-        - Release is 'testing' -> use testing/stable/unstable aliases
-        - Release is 'stable' -> use release name directly
-        - Release is 'oldstable' or 'oldoldstable' -> use release name directly
+    Strategy:
+        - If a USR Merge release (bookworm/trixie) is detected alongside a pre-USR Merge target
+        release (bullseye and below) in stable or testing, use the release name directly to avoid
+        usr-merge conflicts.
+        - If the release does not exist in the snapshot, 
+        fallback to testing/stable/unstable aliases.
+        - If the release is in testing, 
+        use testing/stable/unstable aliases.
+        - If the release is a USR Merge release (bookworm/trixie) in stable, 
+        use testing/stable/unstable aliases.
+        - If the release is a pre-USR Merge release in stable/oldstable/oldoldstable, 
+        use the release name directly.
                          
     Args:
         snapshot_id (str): The snapshot identifier used to build the snapshot URL.
-        vuln_fixed (bool): If the vulnerability has been fixed.
         release (str): Debian release (e.g. 'bullseye', 'bookworm'). Defaults to None.
 
     Returns:
-        list[str]: A list of APT source lines to add to the Dockerfile. Returns an empty list if the vulnerability is not fixed.
+        list[str]: A list of APT source lines to add to the Dockerfile.
+        Returns an empty list if the vulnerability is not fixed.
     """
     options = (
         "[check-valid-until=no allow-insecure=yes allow-downgrade-to-insecure=yes]"
     )
     url = f"http://snapshot.debian.org/archive/debian/{snapshot_id}/"
-    if vuln_fixed:
-        # See https://wiki.debian.org/UsrMerge for more details on usr-merge
-        USR_MERGE_RELEASES = ["bookworm", "trixie"]
-        if release in USR_MERGE_RELEASES or release is None:
+
+    aliases = get_snapshot_aliases(snapshot_id)
+    # See https://wiki.debian.org/UsrMerge for more details on usr-merge
+    usr_merge_releases = ["bookworm", "trixie"]
+
+    # Check if a USR Merge release is present in stable or testing in the snapshot
+    usr_merge_in_stable_or_testing = False
+    for alias, target in aliases.items():
+        if alias in ["stable", "testing"] and target in usr_merge_releases:
+            usr_merge_in_stable_or_testing = True
+            break
+
+    # USR Merge conflict only if this two conditions are met
+    usr_merge_conflict = (release not in usr_merge_releases) and usr_merge_in_stable_or_testing
+
+    if usr_merge_conflict:
+        # Pre-USR Merge release alongside a USR Merge release, use release name directly
+        return [f"deb {options} {url} {release} main"]
+
+    release_exists_in_snapshot = release in aliases.values()
+
+    if not release_exists_in_snapshot:
+        # Release not found in snapshot, fallback to testing/stable/unstable aliases
+        releases = ["testing", "stable", "unstable"]
+        return [f"deb {options} {url} {rel} main" for rel in releases]
+
+    # Find the alias of the target release in the snapshot
+    release_alias = "not_found"
+    for alias, target in aliases.items():
+        if target == release:
+            release_alias = alias
+            break
+
+    match release_alias:
+        case "testing":
+            # Release is testing in the snapshot, use testing/stable/unstable aliases
             releases = ["testing", "stable", "unstable"]
             return [f"deb {options} {url} {rel} main" for rel in releases]
-
-        aliases = get_snapshot_aliases(snapshot_id)
-        release_alias = next(
-        (alias for alias, target in aliases.items() if target == release),
-        "not_found")
-
-        match release_alias:
-            case "testing":
+        case "stable" | "oldstable" | "oldoldstable":
+            if release in usr_merge_releases:
+                # USR Merge release in stable, use testing/stable/unstable aliases
                 releases = ["testing", "stable", "unstable"]
                 return [f"deb {options} {url} {rel} main" for rel in releases]
-
-            case "stable" | "oldstable" | "oldoldstable":
-                return [f"deb {options} {url} {release} main"]
-            
-            case _:
-                return [f"deb {options} {url} {release} main"]
+            # Pre-USR Merge release, use release name directly
+            return [f"deb {options} {url} {release} main"]
+        case _:
+            # Default case, use release name directly (should never happen)
+            return [f"deb {options} {url} {release} main"]
 
 
 # pylint: disable=too-many-locals
@@ -743,13 +800,17 @@ def init_decret():  # pragma: no cover
             )
             browser = None
             args.selenium = None
-
     return args, browser
 
 
 def main():  # pragma: no cover
-    args, browser = init_decret()
+    """
+    Main entry point for the CVE analysis and Dockerfile generation workflow.
 
+    Raises:
+        FatalError: If CVE details cannot be retrieved by any method.
+    """
+    args, browser = init_decret()
     # Then get the details for the given CVE
     try:
         # We try to get the details by the Debian JSON
@@ -760,29 +821,23 @@ def main():  # pragma: no cover
             raise FatalError(
                 "Can't get the details for CVE. Please consider using --selenium."
             ) from exc
-
         try:
             cve_details = get_cve_details_from_selenium(browser, args)
         except ReleaseNotAffectedByCVE as invalid_exc:
             raise FatalError(
                 f"\n{invalid_exc}"
             ) from invalid_exc
-        
         except Exception as selenium_exc:
             raise FatalError(
                 "Error while retrieving CVE details using Selenium"
-            ) from selenium_exc 
-        
+            ) from selenium_exc
     except ReleaseNotAffectedByCVE as exc:
-        raise FatalError(exc)
-   
-    print(f"CVE details fetched.\n {cve_details}\n\n") 
-    
+        raise FatalError(exc) from exc
+    print(f"CVE details fetched.\n {cve_details}\n\n")
     # Get the vulnerable version for the affected package.
     print("Getting the vulnerable version.")
     cve_details = get_vuln_version(args, cve_details)
     print(f"vulnerable version : {cve_details[0]['vuln_version']}\n\n")
-    
     # We determine if the vulnerability is fixed or not
     print("Getting the hash of the package")
     cve_details = get_hash_and_bin_names(args, cve_details)
@@ -803,7 +858,8 @@ def main():  # pragma: no cover
         finally:
             browser.quit()
 
-    source_lines = prepare_sources(snapshot_id)
+    source_lines = prepare_sources(snapshot_id, args.release)
+
     write_dockerfile(args, cve_details, source_lines)
     write_cmdline(args)
     if args.only_create_dockerfile:
@@ -813,5 +869,5 @@ def main():  # pragma: no cover
     if args.dont_run or RUNS_ON_GITHUB_ACTIONS:
         print("My work here is done.")
         return
-
     run_docker(args)
+    

--- a/decret/decret.py
+++ b/decret/decret.py
@@ -459,13 +459,20 @@ def get_vuln_version(args: argparse.Namespace, cve_details: list[dict]) -> list[
 
 
 def get_bin_names(cve_details: list[dict]) -> list[str]:
+    """
+    For each package in cve_details, retrieves the binary package names associated with the vulnerable version.
+    Excludes debug, development, documentation and installer packages.
+    """
+    EXCLUDED_SUFFIXES = {'-dbgsym', '-dbg', '-udeb', '-doc', '-dev'}
     bin_names = []
     for item in cve_details:
         # pylint: disable=line-too-long
         url = f"http://snapshot.debian.org/mr/package/{item['src_package']}/{item['vuln_version']}/binpackages"
         response = requests.get(url, timeout=DEFAULT_TIMEOUT).json()["result"]
         for res in response:
-            bin_names.append(res["name"])
+            name = res["name"]
+            if not any(name.endswith(suffix) for suffix in EXCLUDED_SUFFIXES):
+                bin_names.append(name)
 
     return bin_names
 

--- a/decret/decret.py
+++ b/decret/decret.py
@@ -557,13 +557,81 @@ def write_cmdline(args: argparse.Namespace):
         cmdline_file.write("\n")
 
 
-def prepare_sources(snapshot_id: str):
+def get_snapshot_aliases(snapshot_id: str) -> dict:
+    """
+    Parses the snapshot directory to find alias mappings to their actual releases.
+
+    Args:
+        snapshot_id (str): The snapshot identifier (e.g.'20250624T023934Z').
+
+    Returns:
+        dict: A dictionary mapping aliases to release names.
+              For example: {'stable': 'bookworm', 'testing': 'trixie', 'oldstable': 'bullseye', 'oldoldstable': 'buster', 'unstable': 'sid'}
+    """
+    url = f"http://snapshot.debian.org/archive/debian/{snapshot_id}/dists/"
+    try:
+        server_answer = requests.get(url, timeout=DEFAULT_TIMEOUT)
+        server_answer.raise_for_status()
+    except Exception as exc:
+        print(f"Could not parse snapshot aliases: {exc}")
+        return {}
+    
+    aliases = {}
+
+    # Match HTML symlink entries like: <a href="oldstable">oldstable</a> -&gt; <a href="bullseye">bullseye</a>
+    pattern = re.compile(r'<a href="(stable|testing|unstable|oldstable|oldoldstable)">\1</a>\s*-&gt;\s*<a href="([\w-]+)">\2</a>')
+
+    for match in pattern.finditer(server_answer.text):
+        alias = match.group(1).strip()
+        target = match.group(2).strip()
+        aliases[alias] = target
+
+    return aliases
+
+
+def prepare_sources(snapshot_id: str, vuln_fixed: bool, release: str = None):
+    """
+    Generates the Debian snapshot APT source lines for the Dockerfile.
+    For bookworm/trixie, uses the original alias-based logic (testing/stable/unstable). 
+    For older releases, parses the snapshot to determine the correct source strategy:
+        - Release is 'testing' -> use testing/stable/unstable aliases
+        - Release is 'stable' -> use release name directly
+        - Release is 'oldstable' or 'oldoldstable' -> use release name directly
+                         
+    Args:
+        snapshot_id (str): The snapshot identifier used to build the snapshot URL.
+        vuln_fixed (bool): If the vulnerability has been fixed.
+        release (str): Debian release (e.g. 'bullseye', 'bookworm'). Defaults to None.
+
+    Returns:
+        list[str]: A list of APT source lines to add to the Dockerfile. Returns an empty list if the vulnerability is not fixed.
+    """
     options = (
         "[check-valid-until=no allow-insecure=yes allow-downgrade-to-insecure=yes]"
     )
     url = f"http://snapshot.debian.org/archive/debian/{snapshot_id}/"
-    release = ["testing", "stable", "unstable"]
-    return [f"deb {options} {url} {rel} main" for rel in release]
+    if vuln_fixed:
+        # See https://wiki.debian.org/UsrMerge for more details on usr-merge
+        USR_MERGE_RELEASES = ["bookworm", "trixie"]
+        if release in USR_MERGE_RELEASES or release is None:
+            releases = ["testing", "stable", "unstable"]
+            return [f"deb {options} {url} {rel} main" for rel in releases]
+
+        aliases = get_snapshot_aliases(snapshot_id)
+        release_alias = next(
+        (alias for alias, target in aliases.items() if target == release),
+        "not_found")
+
+        match release_alias:
+            case "testing":
+                releases = ["testing", "stable", "unstable"]
+                return [f"deb {options} {url} {rel} main" for rel in releases]
+
+            case "stable" | "oldstable" | "oldoldstable":
+                return [f"deb {options} {url} {release} main"]
+            
+            case _:
+                return [f"deb {options} {url} {release} main"]
 
 
 # pylint: disable=too-many-locals
@@ -729,7 +797,6 @@ def main():  # pragma: no cover
             browser.quit()
 
     source_lines = prepare_sources(snapshot_id)
-
     write_dockerfile(args, cve_details, source_lines)
     write_cmdline(args)
     if args.only_create_dockerfile:

--- a/decret/decret.py
+++ b/decret/decret.py
@@ -372,9 +372,10 @@ def get_cve_details_from_json(args: argparse.Namespace) -> list[dict]:
             json_cache_file.write_bytes(server_answer.content)
             print(f"Debian tracker JSON saved at {args.cache_main_json_file}.")
 
-    results = []
-
     cve_id = f"CVE-{args.cve_number}"
+
+    # Step 1: Retrieve all occurrences of the CVE for the given release
+    affected_packages = []
     for package_name, package_info in response.items():
         if cve_id not in package_info:
             continue
@@ -382,7 +383,14 @@ def get_cve_details_from_json(args: argparse.Namespace) -> list[dict]:
         cve_info = package_info[cve_id]
         if args.release not in cve_info["releases"]:
             continue
+        affected_packages.append((package_name, cve_info))
 
+    if not affected_packages: 
+        raise CVENotFound("No affected package found.")
+        
+    # Step 2: Build results, skip packages with fixed_version == "0", only if other packages have a valid fixed_version
+    results = []
+    for package_name, cve_info in affected_packages:
         # Get the release specific info for this CVE
         release_info = cve_info["releases"][args.release]
         vulnerable_version = None
@@ -396,13 +404,8 @@ def get_cve_details_from_json(args: argparse.Namespace) -> list[dict]:
         else:
             # If fixed, get the fixed version package
             fixed_version = cve_info["releases"][args.release]["fixed_version"]
-        if fixed_version == "0":
-            raise ReleaseNotAffectedByCVE(
-                f"Debian {args.release} was not affected by {cve_id}.\n"
-                f"Try another release."
-                f"(see https://security-tracker.debian.org/tracker/CVE-{args.cve_number})."
-            )
-
+            if fixed_version == "0":
+                continue
         #Build the result (dictionary) for this package/release
         result = {
                 "src_package": package_name,
@@ -414,8 +417,15 @@ def get_cve_details_from_json(args: argparse.Namespace) -> list[dict]:
             result["vulnerable_version"] = vulnerable_version
         
         results.append(result)
+        break # Only one valid package is selected
+
+    # All packages were filtered out (fixed_version == "0"): the release is not affected by the CVE
     if not results:
-        raise CVENotFound("No affected package found.")
+        raise CVENotFound(
+            f"Debian {args.release} was not affected by {cve_id}.\n"
+            f"Try another release. "
+            f"(see https://security-tracker.debian.org/tracker/CVE-{args.cve_number})."
+        )
 
     return results
 
@@ -547,15 +557,13 @@ def write_cmdline(args: argparse.Namespace):
         cmdline_file.write("\n")
 
 
-def prepare_sources(snapshot_id: str, vuln_fixed: bool):
+def prepare_sources(snapshot_id: str):
     options = (
         "[check-valid-until=no allow-insecure=yes allow-downgrade-to-insecure=yes]"
     )
     url = f"http://snapshot.debian.org/archive/debian/{snapshot_id}/"
-    if vuln_fixed:
-        release = ["testing", "stable", "unstable"]
-        return [f"deb {options} {url} {rel} main" for rel in release]
-    return []
+    release = ["testing", "stable", "unstable"]
+    return [f"deb {options} {url} {rel} main" for rel in release]
 
 
 # pylint: disable=too-many-locals
@@ -693,8 +701,6 @@ def main():  # pragma: no cover
     except ReleaseNotAffectedByCVE as exc:
         raise FatalError(exc)
    
-    # vuln_fixed is False if (unfixed) in cve_details
-    vuln_fixed = not any(item["fixed_version"] == "(unfixed)" for item in cve_details)
     print(f"CVE details fetched.\n {cve_details}\n\n") 
     
     # Get the vulnerable version for the affected package.
@@ -722,10 +728,7 @@ def main():  # pragma: no cover
         finally:
             browser.quit()
 
-    source_lines = prepare_sources(snapshot_id, vuln_fixed)
-    if not vuln_fixed:
-        print(f"\n\nVulnerability unfixed. Using a {LATEST_RELEASE} container.\n\n")
-        args.release = LATEST_RELEASE
+    source_lines = prepare_sources(snapshot_id)
 
     write_dockerfile(args, cve_details, source_lines)
     write_cmdline(args)

--- a/decret/decret.py
+++ b/decret/decret.py
@@ -318,6 +318,20 @@ def get_cve_details_from_selenium(browser, args: argparse.Namespace) -> list[dic
 
 
 def get_cve_details_from_json(args: argparse.Namespace) -> list[dict]:
+    """
+    Parses the Debian Security Tracker JSON file to extract details about a given CVE for a specific Debian release.
+    Supports loading the JSON from a cache file if provided, otherwise fetches it from the official Debian tracker.
+    Handles cases where the package is present but the vulnerability is not fixed, by checking the repositories field:
+    - If the CVE is fixed for the current release, returns a list with: {'src_package', 'release', 'fixed_version'}.
+    - If the CVE is unfixed and the vulnerable package is not found retun a list with : {'src_package', 'release', 'unfixed'}
+    - If the CVE is unfixed but the vulnerable package is available, adds the key 'vulnerable_version' to {'src_package', 'release', 'unfixed'}.
+
+    Returns:
+        cve_details: a list of dictionaries with the package name, release, and fix status.
+
+    Raises:
+        CVENotFound: If no affected package is found for the given CVE and release.
+    """
     response = None
     if args.cache_main_json_file:
         json_cache_file = Path(args.cache_main_json_file)
@@ -345,8 +359,16 @@ def get_cve_details_from_json(args: argparse.Namespace) -> list[dict]:
         if args.release not in cve_info["releases"]:
             continue
 
-        if cve_info["releases"][args.release]["status"] == "open":
+        # Get the release specific info for this CVE
+        release_info = cve_info["releases"][args.release]
+        vulnerable_version = None
+
+        # If the vulnerability is still open (unfixed)
+        if release_info["status"] == "open":
             fixed_version = "(unfixed)"
+            # Try to get the vulnerable version from the repositories field (`repositories` key)
+            repositories = release_info.get("repositories", {})
+            vulnerable_version = repositories.get(args.release)
         else:
             fixed_version = cve_info["releases"][args.release]["fixed_version"]
         if fixed_version == "0":
@@ -355,14 +377,18 @@ def get_cve_details_from_json(args: argparse.Namespace) -> list[dict]:
                 f"Try another release."
                 f"(see https://security-tracker.debian.org/tracker/CVE-{args.cve_number})."
             )
-        results.append(
-            {
+
+        #Build the result (dictionary) for this package/release
+        result = {
                 "src_package": package_name,
                 "release": args.release,
                 "fixed_version": fixed_version,
-            }
-        )
-
+        }
+        # If a vulnerable version is available, add it to the result
+        if vulnerable_version:
+            result["vulnerable_version"] = vulnerable_version
+        
+        results.append(result)
     if not results:
         raise CVENotFound("No affected package found.")
 
@@ -377,8 +403,16 @@ def get_vuln_version(args: argparse.Namespace, cve_details: list[dict]) -> list[
         url = f"http://snapshot.debian.org/mr/package/{item['src_package']}/"
         response = requests.get(url, timeout=DEFAULT_TIMEOUT).json()["result"]
         known_versions = [x["version"] for x in response if "~bpo" not in x["version"]]
+        # If the package is unfixed
         if item["fixed_version"] == "(unfixed)":
-            item["vuln_version"] = known_versions[0]  # We select the latest version
+            # If a vulnerable version is already known (from the JSON), we use it
+            if "vulnerable_version" in item and item["vulnerable_version"]:
+                item["vuln_version"] = item["vulnerable_version"]
+            # Otherwise, we use the latest available version from snapshot.debian.org (index 0)
+            elif known_versions:
+                item["vuln_version"] = known_versions[0]
+            else:
+                item["vuln_version"] = None   
         else:
             for version, prev_version in zip(known_versions[:-1], known_versions[1:]):
                 if version == item["fixed_version"]:
@@ -404,6 +438,17 @@ def get_bin_names(cve_details: list[dict]) -> list[str]:
 def get_hash_and_bin_names(
     args: argparse.Namespace, cve_details: list[dict]
 ) -> list[dict]:
+    """
+    For each package in cve_details, retrieves the hash of the vulnerable version and the associated binary package name.
+    Tries to fetch the hash from the binary files.
+    Updates each dictionary with the 'hash' and 'bin_name' keys.
+
+    Returns:
+        cve_details: The updated list of dictionaries with hash and binary package name information.
+
+    Raises:
+        Exception: If no binary/source files are found, or if the binary package name is invalid.
+    """
     i = 0
     for item in cve_details:
         try:
@@ -622,7 +667,8 @@ def main():  # pragma: no cover
     print("Getting the vulnerable version.")
     cve_details = get_vuln_version(args, cve_details)
     print(f"vulnerable version : {cve_details[0]['vuln_version']}\n\n")
-
+    # We determine if the vulnerability is fixed or not
+    vuln_fixed = not any(item["fixed_version"] == "(unfixed)" for item in cve_details)
     print("Getting the hash of the package")
     cve_details = get_hash_and_bin_names(args, cve_details)
     print(f"Source package hash : {cve_details[0]['hash']}\n\n")
@@ -643,9 +689,12 @@ def main():  # pragma: no cover
             browser.quit()
 
     source_lines = prepare_sources(snapshot_id, vuln_fixed)
+    # If the vulnerability is unfixed and the version is not found, use the latest release
     if not vuln_fixed:
         print(f"\n\nVulnerability unfixed. Using a {LATEST_RELEASE} container.\n\n")
         args.release = LATEST_RELEASE
+    else:
+        print("\n\nVulnerable package available.\n\n")
 
     write_dockerfile(args, cve_details, source_lines)
     write_cmdline(args)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 """
 Software Name : decret (DEbian Cve REproducer Tool)
 Version : 0.1
-SPDX-FileCopyrightText : Copyright (c) 2023-2025 Orange
+SPDX-FileCopyrightText : Copyright (c) 2023-2026 Orange
 SPDX-License-Identifier : BSD-3-Clause
 
 This software is distributed under the BSD 3-Clause "New" or "Revised" License,
@@ -9,7 +9,7 @@ the text of which is available at https://opensource.org/licenses/BSD-3-Clause
 or see the "license.txt" file for more not details.
 
 Authors : Clément PARSSEGNY, Olivier LEVILLAIN, Maxime BELAIR, Mathieu BACOU,
-Nicolas DEJON
+Nicolas DEJON, Zakaria CHAKER
 Software description : A tool to reproduce vulnerability affecting Debian
 It gathers details from the Debian metadata and exploits from exploit-db.com
 in order to build and run a vulnerable Docker container to test and

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -1,7 +1,7 @@
 """
 Software Name : decret (DEbian Cve REproducer Tool)
 Version : 0.1
-SPDX-FileCopyrightText : Copyright (c) 2023-2025 Orange
+SPDX-FileCopyrightText : Copyright (c) 2023-2026 Orange
 SPDX-License-Identifier : BSD-3-Clause
 
 This software is distributed under the BSD 3-Clause "New" or "Revised" License,
@@ -9,7 +9,7 @@ the text of which is available at https://opensource.org/licenses/BSD-3-Clause
 or see the "license.txt" file for more not details.
 
 Authors : Clément PARSSEGNY, Olivier LEVILLAIN, Maxime BELAIR, Mathieu BACOU,
-Nicolas DEJON
+Nicolas DEJON, Zakaria CHAKER
 Software description : A tool to reproduce vulnerability affecting Debian
 It gathers details from the Debian metadata and exploits from exploit-db.com
 in order to build and run a vulnerable Docker container to test and

--- a/tests/test_cve_debian.py
+++ b/tests/test_cve_debian.py
@@ -1,7 +1,7 @@
 """
 Software Name : decret (DEbian Cve REproducer Tool)
 Version : 0.1
-SPDX-FileCopyrightText : Copyright (c) 2023-2025 Orange
+SPDX-FileCopyrightText : Copyright (c) 2023-2026 Orange
 SPDX-License-Identifier : BSD-3-Clause
 
 This software is distributed under the BSD 3-Clause "New" or "Revised" License,
@@ -9,7 +9,7 @@ the text of which is available at https://opensource.org/licenses/BSD-3-Clause
 or see the "license.txt" file for more not details.
 
 Authors : Clément PARSSEGNY, Olivier LEVILLAIN, Maxime BELAIR, Mathieu BACOU,
-Nicolas DEJON
+Nicolas DEJON, Zakaria CHAKER
 Software description : A tool to reproduce vulnerability affecting Debian
 It gathers details from the Debian metadata and exploits from exploit-db.com
 in order to build and run a vulnerable Docker container to test and


### PR DESCRIPTION
1. Retrieve vulnerable version from JSON when CVE has an unfixed status
2. Fix JSON parsing when multiple packages exist for the same CVE, selecting the one with a valid fixed version
3. Fix invalid package name handling by introducing a dedicated exception
4. Fix case where a release is not affected by the CVE, properly skipping it with ReleaseNotAffectedByCVE exception
5. Fix snapshot alias parsing to determine correct sources in prepare_sources
6. Filter out debug/udeb/doc/dev packages in get_bin_names to prevent Dockerfile build failures
7. Fix usr-merge conflicts and snapshot fallback in prepare_sources